### PR TITLE
Fix the ZK thread leak while closing connection.

### DIFF
--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -23,7 +23,7 @@ class Nerve::Reporter
 
     def stop()
       log.info "nerve: closing zk connection at #{@path}"
-      @zk.close
+      @zk.close!
     end
 
     def report_up()


### PR DESCRIPTION
This closes the reconnect thread used in nerve which was the cause of thread leak when Zookeeper instance goes down. 
